### PR TITLE
Enable BrowserSync, but with ghostMode disabled.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,3 +112,6 @@ prism_plus:
 
 deploy:
   type:
+
+browsersync:
+  ghostMode: false


### PR DESCRIPTION
The Hexo BrowserSync plugin is great for auto-reloading documentation pages when their source content has changed.

That functionality alone merely requires the installation of the `hexo-browsersync` package but this additional configuration (specifically the `ghostMode: false`) disables the additional BrowserSync functionality which makes each connected client also synchronize the scrolling and navigation with other connected clients (which acts like a screen-sharing mode).  Interesting, but unnecessary!